### PR TITLE
Ensure flattened carousel dates respect theme colors

### DIFF
--- a/components/molecules/Carousel.tsx
+++ b/components/molecules/Carousel.tsx
@@ -104,6 +104,10 @@ const Carousel: React.FC<CarouselProps> = ({ items, isFlattened = false }) => {
           .flattened-content > :global(.paragraph) {
             margin-bottom: 20px;
           }
+
+          .flattened-content > :global(.paragraph.color-secondary) {
+            color: var(--text);
+          }
         `}</style>
       </>
     );


### PR DESCRIPTION
## Summary
- restore the dark theme secondary paragraph token so existing layouts keep their original appearance
- override secondary paragraphs in the flattened carousel to inherit the active text color for proper contrast in both themes

## Testing
- yarn lint

------
https://chatgpt.com/codex/tasks/task_e_68fbc21b9bd8832cbe17d759a682b08b