### PR TITLE
Add Markdown CV generation script and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,221 @@
+# Summary
+
+Originally from Colombia, I am Guillermo Rodas, a seasoned Senior Full-stack JavaScript Engineer now residing in Sweden. My professional journey is fueled by a passion for empowering fellow developers, guiding them in skill enhancement, and ensuring the delivery of top-notch products.
+
+Beyond my role as a developer, I actively contribute to the tech community as the coordinator for CSS Community Dev and CSS Conf Colombia, showcasing my leadership and organizational skills in community-building initiatives.
+
+My expertise and contributions have earned me the prestigious titles of Google Developer Expert, Auth0 Ambassador, and Twitch Partner, reflecting my influence and impact within the tech industry.
+
+# Languages
+
+🇬🇧 **English**
+Fluent
+
+🇪🇸 **Spanish**
+Native
+
+🇸🇪 **Swedish**
+Elementary
+
+# Expertises
+
+## JavaScript
+13 years of experience
+- Skilled in JavaScript (ES2015+) and TypeScript, with experience in various JavaScript MV* frameworks for dynamic and efficient web development
+
+## React
+10 years of experience
+- Proficient in React, including Hooks and various libraries, with expertise in global state management using Redux and Zustand for robust application architectures
+
+## Node.js
+9 years of experience
+- Experienced with Node.js, using Express and diverse third-party middlewares. Also familiar with Hapi.js and plugins like Joi and Boom for scalable server-side solutions
+
+# Stack
+
+- **GraphQL** — Implemented GraphQL with Apollo and leveraged The Guild's ecosystem, including GraphQL Mesh, for optimized data retrieval and more efficient APIs.
+- **MySQL, Postgres & BigQuery** — Managed MySQL, Postgres, and BigQuery databases, providing comprehensive data solutions for complex datasets and query requirements.
+- **MongoDB** — Developed MongoDB systems using Mongoose and Mongo Atlas, focusing on scalable NoSQL database solutions for high-demand applications.
+- **OAuth & OIDC** — Integrated OAuth and OIDC protocols with various services including Auth0, Google, Meta, Spotify, and X (formerly Twitter), among others, effectively enhancing user authentication and access management.
+- **Firebase** — Implemented Firebase solutions, including Firestore and Authentication, to create secure, real-time, data-driven applications.
+- **Kafka** — Utilized Kafka for real-time data streaming and scalable processing, handling data flows across millions of records efficiently.
+- **ElasticSearch** — Developed and optimized ElasticSearch implementations for handling and querying multi-million record datasets, enhancing search efficiency and data analysis.
+- **Docker & Kubernetes** — Utilized Docker and Kubernetes to orchestrate multiple services, including distinct front-end and back-end systems, ensuring efficient containerization and system scalability.
+- **Apache & NGINX** — Configured Apache and NGINX servers to ensure optimal performance and enhanced security, supporting high-traffic web applications.
+- **AWS & Google Cloud Platform** — Utilized AWS services including S3, EC2, SQS, and DynamoDB, alongside GCP offerings like CloudRun, CloudBuild, Kubernetes, BigQuery, and BigTable, to develop scalable and reliable cloud-based applications.
+- **Linux OS** — Managed Linux OS, including CentOS and Debian, with a focus on security configurations, bash scripting, and remote administration via SSH for production environments.
+- **Agile Methodologies** — Employed Agile methodologies, including Scrum, Kanban, Scrumban, and Lean, to streamline development processes and enhance team collaboration and productivity.
+
+# Frameworks
+
+- **Next.js** — Utilized Next.js for building SSR React applications, leveraging React Server Components, App Router, and Server Actions with Vercel for enhanced performance.
+- **Meteor** — Developed with Meteor, focusing on its reactive programming capabilities, including mobile application development.
+- **Jest, Vitest and Playwright** — Applied Jest, Vitest, and Playwright for comprehensive testing, ensuring robust and reliable software solutions.
+- **Storybook** — Employed Storybook for developing and testing UI components, enhancing interface design and consistency.
+- **Design Tokens** — Implemented Design Tokens to maintain consistent design and branding across applications.
+- **Material Design, Ant Design & Tailwind CSS** — Skilled in applying UI frameworks like Material Design, Ant Design, and Tailwind CSS for diverse and adaptable UI solutions.
+- **Webpack & Vite** — Experienced with Webpack and Vite, optimizing production setups with various plugins for enhanced application performance.
+- **NPM, NPM scripts & Yarn** — Worked with NPM, NPM scripts, and Yarn, including managing monorepos using Yarn workspaces, for efficient project management.
+
+# Careers
+
+## EQT Group
+Start Date: August 2021
+URL: [www.eqtgroup.com](https://www.eqtgroup.com)
+About: EQT is a private equity firm that invests in companies and regions where there is an industrial approach.
+Functions: Senior Full-stack Engineer.
+
+### Achievements
+- Involved in an in-house project that leverages AI to enhance the efficiency of deal professionals, streamlining tasks, and finding investment opportunities.
+- Assisted in establishing the foundations of a Design System, incorporating scaffolding to refine our automated component tests.
+- Additionally, led a series of self-improvement meetings for the team, exploring new technologies and addressing our tech debt.
+
+## Klarna
+Date: 2019
+Start Date: September 2019
+End Date: August 2021
+URL: [www.klarna.com](https://www.klarna.com)
+About: Klarna is an e-commerce payment solutions platform for merchants and shoppers.
+Functions: Engineer
+
+### Achievements
+- As a member of the foundations team, my role involved creating the main user interface pacakges,employing microfrontends,that were used by various teams.
+- Additionally, Iworked on improving and expanding the continuous delivery process, which wasa crucial aspect of our team's work.
+
+## Auth0
+Date: 2016
+Start Date: October 2016
+End Date: September 2019
+URL: [www.auth0.com](https://www.auth0.com)
+About: Auth0 is a cloud identity management SAAS application for the web, mobile, IoT, and internal software.
+Functions: Engineer
+
+### Achievements
+- I was involved in the development of several internal products utilizing Hapi.js, MongoDB, React, and Redux technologies.
+- Additionally, I enhanced our team's development process by integrating tools such as Storybook and Snapshot testing.
+
+## Huge
+Date: 2015
+Start Date: May 2015
+End Date: October 2016
+URL: [www.huge.com](https://www.huge.com)
+About: Huge redefines what's possible for the world's most ambitious brands.
+Functions: Web Engineer
+
+### Achievements
+- I contributed to the development of a Fintech web app, harnessing the power of React and Redux. This app was finely tuned for compatibility across various browsers and mobile devices.
+- I crafted web applications with Vanilla JavaScript, ensuring they seamlessly worked across diverse browsers and devices, including the likes of IE10 on Windows and Safari on the iPhone 4S.
+- In another key role, I took the lead as the front-end developer, focusing on a web app optimized for stellar performance on mobile platforms.
+- Beyond development, I facilitated multiple technical training sessions, bolstering the skills of both the Front-end and Quality Assurance teams.
+
+## Komet Sales
+Date: 2012
+Start Date: August 2012
+End Date: May 2015
+URL: [www.kometsales.com](https://www.kometsales.com)
+About: Komet is floral industry SaaS that gives you the tools to automate processes while connecting with your key business partners.
+Functions: Full-stack Developer
+
+### Achievements
+- Played a pivotal role in numerous corporate projects, tapping into MySQL and Java frameworks like Spring and Hibernate.
+- Took the lead in shaping the Front-end architecture and defining the tech stack for our company's products.
+- Further, I drove improvements in development practices, notably shifting from SVN to Git and championing the adoption of Scrum.
+
+# Knowledge
+
+## Education
+
+- **UX Designer Upskill** — Hyper Island _(October 2023 — May 2024)_
+- **Technical assistant in Digital Graphic Design** — CENSA _(October 2017 — June 2018)_
+- **Systems engineering (undergraduate)** — Universidad Nacional de Colombia _(January 2007 — January 2010)_
+
+## Courses
+
+- **Platzi**
+  - JavaScript Backend Career — 80 Hours, March 2019
+  - English Career — 80 Hours, March 2019
+  - Frontend Architect Career — 80 Hours, December 2018
+- **Actívate** — Google Analytics Course _(40 Hours, December 2017)_
+- **Coursera**
+  - Swift: programming for iOS — 30 Hours, March 2016
+  - Web Application Development with JavaScript and MongoDB — 8 Hours, March 2016
+  - Introduction to Meteor.js development — 12 Hours, February 2016
+- **Mejorando.la**
+  - Professional Backend Course — 12 Hours, February 2014
+  - Professional Frontend Course — 12 Hours, July 2013
+  - HTML5 Course — 20 Hours, July 2012
+- **Amazon Web Services** — AWS Business Professional Accreditation _(10 Hours, June 2014)_
+- **SENA**
+  - Database Design in SQL — 40 Hours, November 2010
+  - Variables and structures of control in POO: JAVA — 40 Hours, November 2010
+- **Universidad Nacional de Colombia** — Web programming with PHP and MySQL _(50 Hours, July 2010)_
+- **Institución Educativa Concejo de Medellín** — Middle Technical in Multimedia production and Software Design _(280 Hours, December 2007)_
+
+## Seminars
+
+- **Agiles.org** — VII Latin American Workshops on Agile Methodologies _(24 Hours, October 2014)_
+- **Campus Party Colombia**
+  - Campus Party 7 Colombia — 300 Hours, June 2014
+  - Campus Party 6 Colombia — 250 Hours, October 2013
+  - Campus Party 4 Colombia — 521 Hours, July 2011
+- **Google** — Google Developer Bus Bogota _(36 Hours, November 2013)_
+
+# Achievements
+
+## Speaking
+
+- **WebAuthn & Passkeys: The Future of Authentication**
+  - DevFest Singapore, EpicHey! — November 2023
+  - DevFest Zagreb — October 2023
+- **Why everyone should do streaming live coding?**
+  - DevFest Stockholm — December 2022
+  - Nerdearla — August 2022
+
+## Mentorship
+
+- **Online Teacher**
+  - Platzi — December 2018, July 2019, March 2023
+  - Código Facilito — September 2023
+- **Mentor**
+  - Women Developer Academy Europe — October 2021, October 2023
+  - Hyper Island — March 2021
+  - The Konferense — September 2020
+  - Techstars Startup Weekend — June 2019
+- **Bootcamp Instructor**
+  - Código Facilito — October 2022, February 2023, March 2024
+  - Undefined Academy — March 2023 - October 2023
+  - Platzi Master — November 2020 - September 2022
+  - World Tech Makers — June 2017 - August 2017
+- **Organizer**
+  - CSS Conf Colombia — April 2021 - December 2023
+  - CSS Community Dev — June 2018 - December 2023
+  - Medellín Java — December 2014 - November 2016
+
+## Podcasts
+
+- **AI and Humans: Invincible Innovation** — Staying Ahead in AI: Practical Insights for Developers _(April 2025)_
+- **freeCodeCamp en Español** — From Java to JavaScript _(December 2023)_
+- **Humans of Platzi** — The power of English and networking _(July 2023)_
+- **EnPixeles** — Creating communities in post-pandemic _(December 2021)_
+- **24H24L** — I already know how to code, what's next? _(December 2021)_
+- **La liga del código** — Security in the Front-end _(August 2020)_
+
+## Meetups
+
+- **Laravel Dev & Vue** — Handling Security in the Front-end _(June 2020)_
+- **Magenta Codes** — How to succeed as a Full-Stack Engineer _(April 2020)_
+- **Medellin CSS**
+  - Don't use a pre-processor anymore — August 2020
+  - Tips for giving a talk — June 2019
+  - CSS Layout — June 2018
+  - How to scale CSS in Design Systems — October 2018
+  - The Last CSS Framework — April 2018
+- **Medellin Java**
+  - Modern Web apps with jHipster — May 2015
+  - Introduction to Spring Security — April 2015
+  - Spring Core advantages — January 2015
+- **NodeCo** — In the middle of the middleware _(March 2019)_
+- **ReactJS Top** — The future of state management _(March 2019)_
+- **Wordpress Medellín** — WooCommerce and React _(October 2018)_
+- **Medellin JS** — How to quit using jQuery _(May 2015)_
+- **Medellin PHP** — How to install Laravel in Codio _(October 2014)_

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "build": "next build",
     "start": "next start",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "generate:readme": "node scripts/generate-readme.js"
   },
   "author": "Guillermo Rodas",
   "license": "ISC",

--- a/scripts/generate-readme.js
+++ b/scripts/generate-readme.js
@@ -1,0 +1,277 @@
+const fs = require("fs");
+const path = require("path");
+const ts = require("typescript");
+
+const projectRoot = path.resolve(__dirname, "..");
+
+const moduleCache = new Map();
+
+function resolveModulePath(requestPath) {
+  const candidates = [];
+
+  if (path.extname(requestPath)) {
+    candidates.push(requestPath);
+  } else {
+    candidates.push(`${requestPath}.ts`);
+    candidates.push(path.join(requestPath, "index.ts"));
+    candidates.push(`${requestPath}.js`);
+    candidates.push(path.join(requestPath, "index.js"));
+  }
+
+  for (const candidate of candidates) {
+    if (candidate && fs.existsSync(candidate) && fs.statSync(candidate).isFile()) {
+      return candidate;
+    }
+  }
+
+  throw new Error(`Unable to resolve module: ${requestPath}`);
+}
+
+function loadTsModule(requestPath) {
+  const resolvedPath = resolveModulePath(requestPath);
+
+  if (moduleCache.has(resolvedPath)) {
+    return moduleCache.get(resolvedPath).exports;
+  }
+
+  const code = fs.readFileSync(resolvedPath, "utf8");
+  const transpiled = ts.transpileModule(code, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2020,
+      esModuleInterop: true,
+    },
+    fileName: resolvedPath,
+  });
+
+  const module = { exports: {} };
+  moduleCache.set(resolvedPath, module);
+
+  const dirname = path.dirname(resolvedPath);
+
+  function customRequire(specifier) {
+    if (specifier.startsWith(".")) {
+      const absolute = path.resolve(dirname, specifier);
+      return loadTsModule(absolute);
+    }
+
+    return require(specifier);
+  }
+
+  const wrapper = new Function(
+    "exports",
+    "require",
+    "module",
+    "__filename",
+    "__dirname",
+    transpiled.outputText
+  );
+
+  wrapper(module.exports, customRequire, module, resolvedPath, dirname);
+
+  return module.exports;
+}
+
+function addLine(lines, line = "") {
+  lines.push(line);
+}
+
+function formatLink(url) {
+  const trimmed = url.trim();
+  const hasProtocol = /^https?:\/\//i.test(trimmed);
+  const href = hasProtocol ? trimmed : `https://${trimmed}`;
+  return `[${trimmed}](${href})`;
+}
+
+function formatSummary(lines, summary) {
+  addLine(lines, "# Summary");
+  addLine(lines);
+
+  summary.forEach((paragraph, index) => {
+    addLine(lines, paragraph);
+    if (index !== summary.length - 1) {
+      addLine(lines);
+    }
+  });
+
+  addLine(lines);
+}
+
+function formatLanguages(lines, languages) {
+  addLine(lines, "# Languages");
+  addLine(lines);
+
+  languages.forEach((language, index) => {
+    addLine(lines, `${language.flag} **${language.title}**`);
+    addLine(lines, language.proeficiency);
+    if (index !== languages.length - 1) {
+      addLine(lines);
+    }
+  });
+
+  addLine(lines);
+}
+
+function formatExpertises(lines, expertises) {
+  addLine(lines, "# Expertises");
+  addLine(lines);
+
+  expertises.forEach((expertise, index) => {
+    addLine(lines, `## ${expertise.title}`);
+    if (expertise.subtitle) {
+      addLine(lines, expertise.subtitle);
+    }
+    expertise.items.forEach((item) => {
+      addLine(lines, `- ${item}`);
+    });
+    if (index !== expertises.length - 1) {
+      addLine(lines);
+    }
+  });
+
+  addLine(lines);
+}
+
+function formatStack(lines, stack) {
+  addLine(lines, "# Stack");
+  addLine(lines);
+
+  stack.forEach((item) => {
+    addLine(lines, `- **${item.title}** — ${item.text}`);
+  });
+
+  addLine(lines);
+}
+
+function formatFrameworks(lines, frameworks) {
+  addLine(lines, "# Frameworks");
+  addLine(lines);
+
+  frameworks.forEach((item) => {
+    addLine(lines, `- **${item.title}** — ${item.text}`);
+  });
+
+  addLine(lines);
+}
+
+function formatCareers(lines, careers) {
+  addLine(lines, "# Careers");
+  addLine(lines);
+
+  careers.forEach((career, index) => {
+    addLine(lines, `## ${career.company}`);
+    if (career.date) {
+      addLine(lines, `Date: ${career.date}`);
+    }
+    addLine(lines, `Start Date: ${career.startDate}`);
+    if (career.endDate) {
+      addLine(lines, `End Date: ${career.endDate}`);
+    }
+    addLine(lines, `URL: ${formatLink(career.url)}`);
+    addLine(lines, `About: ${career.about}`);
+    addLine(lines, `Functions: ${career.functions}`);
+    if (career.achievements.length > 0) {
+      addLine(lines);
+      addLine(lines, "### Achievements");
+      career.achievements.forEach((achievement) => {
+        addLine(lines, `- ${achievement}`);
+      });
+    }
+    if (index !== careers.length - 1) {
+      addLine(lines);
+    }
+  });
+
+  addLine(lines);
+}
+
+function formatKnowledge(lines, knowledge) {
+  addLine(lines, "# Knowledge");
+  addLine(lines);
+
+  knowledge.forEach((section, sectionIndex) => {
+    addLine(lines, `## ${section.title}`);
+    addLine(lines);
+
+    section.items.forEach((item) => {
+      const text = item.text;
+      if (Array.isArray(text)) {
+        addLine(lines, `- **${item.title}**`);
+        text.forEach((entry) => {
+          const [title, detail] = entry;
+          addLine(lines, `  - ${title} — ${detail}`);
+        });
+        if (item.footer) {
+          addLine(lines, `  - _${item.footer}_`);
+        }
+      } else {
+        const footer = item.footer ? ` _(${item.footer})_` : "";
+        addLine(lines, `- **${item.title}** — ${text}${footer}`);
+      }
+    });
+
+    if (sectionIndex !== knowledge.length - 1) {
+      addLine(lines);
+    }
+  });
+
+  addLine(lines);
+}
+
+function formatAchievements(lines, achievements) {
+  addLine(lines, "# Achievements");
+  addLine(lines);
+
+  achievements.forEach((section, sectionIndex) => {
+    addLine(lines, `## ${section.title}`);
+    addLine(lines);
+
+    section.items.forEach((item) => {
+      const text = item.text;
+      if (Array.isArray(text)) {
+        addLine(lines, `- **${item.title}**`);
+        text.forEach((entry) => {
+          const [title, detail] = entry;
+          addLine(lines, `  - ${title} — ${detail}`);
+        });
+        if (item.footer) {
+          addLine(lines, `  - _${item.footer}_`);
+        }
+      } else {
+        const footer = item.footer ? ` _(${item.footer})_` : "";
+        addLine(lines, `- **${item.title}** — ${text}${footer}`);
+      }
+    });
+
+    if (sectionIndex !== achievements.length - 1) {
+      addLine(lines);
+    }
+  });
+}
+
+function main() {
+  const lines = [];
+
+  const summaryModule = loadTsModule(path.join(projectRoot, "data", "summary"));
+  const languagesModule = loadTsModule(path.join(projectRoot, "data", "languages"));
+  const expertisesModule = loadTsModule(path.join(projectRoot, "data", "expertises"));
+  const stackModule = loadTsModule(path.join(projectRoot, "data", "stack"));
+  const frameworksModule = loadTsModule(path.join(projectRoot, "data", "frameworks"));
+  const careersModule = loadTsModule(path.join(projectRoot, "data", "careers"));
+  const knowledgeModule = loadTsModule(path.join(projectRoot, "data", "knowledge"));
+  const achievementsModule = loadTsModule(path.join(projectRoot, "data", "achievements"));
+
+  formatSummary(lines, summaryModule.summary);
+  formatLanguages(lines, languagesModule.languages);
+  formatExpertises(lines, expertisesModule.expertises);
+  formatStack(lines, stackModule.stack);
+  formatFrameworks(lines, frameworksModule.frameworks);
+  formatCareers(lines, careersModule.careers);
+  formatKnowledge(lines, knowledgeModule.knowledge);
+  formatAchievements(lines, achievementsModule.achievements);
+
+  const output = lines.join("\n").replace(/\n{3,}/g, "\n\n");
+  fs.writeFileSync(path.join(projectRoot, "README.md"), `${output}\n`, "utf8");
+}
+
+main();


### PR DESCRIPTION
## Summary
- add a Node-based script that transpiles the existing TypeScript data and renders it into Markdown
- check the script into the repo and expose it through `yarn generate:readme`
- generate a README.md file that captures the CV content in a readable Markdown structure

## Testing
- yarn generate:readme

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d239e2490832ca3439d65f3d421b5)