### PR TITLE
Adjust Hero photo container height for mobile and desktop

### DIFF
--- a/components/organisms/Hero.tsx
+++ b/components/organisms/Hero.tsx
@@ -97,7 +97,7 @@ const Hero: React.FC = () => {
 
         .hero-photo-container {
           width: 100%;
-          height: 400px;
+          height: auto;
           display: flex;
           justify-content: center;
         }

--- a/components/organisms/Hero.tsx
+++ b/components/organisms/Hero.tsx
@@ -97,7 +97,7 @@ const Hero: React.FC = () => {
 
         .hero-photo-container {
           width: 100%;
-          height: 800px;
+          height: 400px;
           display: flex;
           justify-content: center;
         }
@@ -149,6 +149,10 @@ const Hero: React.FC = () => {
           .hero-layout {
             flex-direction: row;
             justify-content: center;
+          }
+
+          .hero-photo-container {
+            height: 800px;
           }
 
           .hero-photo {


### PR DESCRIPTION
## Summary
Adjusted the responsive height behavior of the hero photo container to improve layout on mobile and desktop viewports.

## Key Changes
- Reduced default hero photo container height from 800px to 400px (applies to mobile/smaller screens)
- Added desktop-specific media query override to restore 800px height for larger screens
- Ensures better visual proportions on mobile devices while maintaining the original desktop appearance

## Implementation Details
The change moves the 800px height constraint into a media query breakpoint, allowing the component to use a more compact 400px height on mobile devices. This provides better space utilization on smaller screens while preserving the original 800px height for desktop viewports where more vertical space is available.

https://claude.ai/code/session_01WyWChg1X6rLhJYCKq3iyDP