### PR TITLE
style(print): overhaul /print route for clean PDF output

### DIFF
--- a/components/molecules/Card.tsx
+++ b/components/molecules/Card.tsx
@@ -67,11 +67,27 @@ const Card: React.FC<CardProps> = ({ title, subtitle, items, isInverted }) => {
         }
 
         @media print {
-          .card {
+          .card,
+          .card--inverted {
+            background: var(--white) !important;
+            border: 1px solid var(--black) !important;
+            padding: 12px 16px !important;
+            margin: 8px 0 !important;
             width: 100% !important;
             max-width: 100% !important;
             break-inside: avoid !important;
             page-break-inside: avoid !important;
+          }
+
+          .card :global(hr),
+          .card--inverted :global(hr) {
+            background: var(--black) !important;
+          }
+
+          .card--inverted header :global(.heading),
+          .card--inverted header :global(.paragraph),
+          .card--inverted :global(.paragraph) {
+            color: var(--black) !important;
           }
         }
       `}</style>

--- a/components/molecules/Job.tsx
+++ b/components/molecules/Job.tsx
@@ -82,23 +82,18 @@ const Job: React.FC<JobProps> = ({ career }) => {
 
         @media print {
           .job {
-            display: grid !important;
-            grid-template-columns: 1fr 1fr !important;
-            gap: 35px !important;
-            grid-template-areas:
-              "header achievements"
-              "about achievements"
-              "functions achievements" !important;
+            display: flex !important;
+            flex-direction: column !important;
+            gap: 18px !important;
           }
 
           .job-header {
-            grid-area: header !important;
             align-items: flex-start !important;
           }
 
           .job-header :global(.logo) {
-            max-width: 200px !important;
-            width: 100% !important;
+            max-width: 160px !important;
+            width: auto !important;
             height: auto !important;
           }
 
@@ -107,24 +102,10 @@ const Job: React.FC<JobProps> = ({ career }) => {
             align-self: flex-start !important;
           }
 
-          .job > div:nth-child(2) {
-            grid-area: about !important;
-          }
-
-          .job > div:nth-child(3) {
-            grid-area: functions !important;
-          }
-
-          .job-achievements {
-            grid-area: achievements !important;
-            grid-column: 2 !important;
-            grid-row: 1 / 5 !important;
-          }
-
           .job-achievements-list {
             display: flex !important;
             flex-direction: column !important;
-            gap: 15px;
+            gap: 10px;
           }
         }
       `}</style>

--- a/components/molecules/SkillCards.tsx
+++ b/components/molecules/SkillCards.tsx
@@ -29,9 +29,10 @@ const SkillCards: React.FC<SkillCardsProps> = ({ skills }) => {
 
         @media print {
           .skills-grid {
-            flex-wrap: wrap !important;
-            justify-content: space-between !important;
-            gap: 30px 30px;
+            display: flex !important;
+            flex-direction: column !important;
+            flex-wrap: nowrap !important;
+            gap: 12px !important;
           }
         }
       `}</style>

--- a/components/organisms/Footer.tsx
+++ b/components/organisms/Footer.tsx
@@ -137,8 +137,31 @@ const Footer: React.FC = () => {
 
         @media print {
           footer {
+            background: var(--white) !important;
+            padding: 30px 0 0 !important;
             break-before: page;
             page-break-before: always;
+          }
+
+          .footer-container {
+            display: flex !important;
+            flex-direction: column !important;
+            gap: 20px !important;
+          }
+
+          .footer-logo {
+            display: none !important;
+          }
+
+          .footer-content {
+            align-items: flex-start !important;
+            padding-bottom: 0 !important;
+          }
+
+          .footer-icon-list :global(a),
+          .footer-social :global(a),
+          .footer-social :global(.heading) {
+            color: var(--black) !important;
           }
         }
       `}</style>

--- a/components/organisms/Knowledge.tsx
+++ b/components/organisms/Knowledge.tsx
@@ -29,11 +29,19 @@ const Knowledge: React.FC<KnowledgeProps> = ({ title, items }) => {
             title: item.title,
             content: (
               <div className="knowledge-masonry">
-                <Masonry columns={isMobile ? 1 : 2}>
-                  {item.items.map((subitem) => (
-                    <Item key={subitem.title} icon="diamond-alt" {...subitem} />
-                  ))}
-                </Masonry>
+                {isFlattened ? (
+                  <div className="knowledge-flat">
+                    {item.items.map((subitem) => (
+                      <Item key={subitem.title} icon="diamond-alt" {...subitem} />
+                    ))}
+                  </div>
+                ) : (
+                  <Masonry columns={isMobile ? 1 : 2}>
+                    {item.items.map((subitem) => (
+                      <Item key={subitem.title} icon="diamond-alt" {...subitem} />
+                    ))}
+                  </Masonry>
+                )}
               </div>
             ),
           }))}
@@ -42,6 +50,12 @@ const Knowledge: React.FC<KnowledgeProps> = ({ title, items }) => {
       <style jsx>{`
         .knowledge-masonry {
           display: block;
+        }
+
+        .knowledge-flat {
+          display: flex;
+          flex-direction: column;
+          gap: 8px;
         }
 
         @media print {

--- a/components/organisms/Profile.tsx
+++ b/components/organisms/Profile.tsx
@@ -58,6 +58,17 @@ const Profile: React.FC = () => {
             grid-gap: 30px;
           }
         }
+
+        @media print {
+          .profile {
+            gap: 16px !important;
+          }
+
+          .languages {
+            flex-direction: column !important;
+            gap: 4px !important;
+          }
+        }
       `}</style>
     </PageContainer>
   );

--- a/pages/print.tsx
+++ b/pages/print.tsx
@@ -1,7 +1,6 @@
 import Head from "next/head";
 import { GetStaticProps } from "next";
 
-import Hero from "../components/organisms/Hero";
 import { printDescription, printPageTitle } from "../data/site";
 import Profile from "../components/organisms/Profile";
 import Career from "../components/organisms/Career";
@@ -25,7 +24,6 @@ const Print = () => {
         <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
       </Head>
       <div className="container print-container">
-        <Hero />
         <Profile />
         <Skills />
         <Career />

--- a/styles/main.scss
+++ b/styles/main.scss
@@ -108,7 +108,21 @@
   /* Page setup */
   @page {
     size: A4;
-    margin: 12mm;
+    margin: 15mm 12mm;
+  }
+
+  /* Force light theme regardless of user preference or system setting */
+  :root,
+  :root.dark {
+    --background: var(--white) !important;
+    --text: var(--black) !important;
+    --text-inverted: var(--black) !important;
+    --primary: var(--black) !important;
+    --secondary: var(--black) !important;
+    --paragraph-primary: var(--black) !important;
+    --paragraph-secondary: var(--black) !important;
+    --heading-secondary: var(--black) !important;
+    --carousel-nav-bg: transparent !important;
   }
 
   /* Force color printing - preserve backgrounds and colors */
@@ -128,19 +142,57 @@
 
   /* Root and body adjustments */
   html {
-    font-size: 10px;
+    font-size: 12px;
   }
 
   body {
-    background-color: var(--background) !important;
+    background-color: var(--white) !important;
+    color: var(--black) !important;
   }
 
   body.footer-visible {
-    background-color: var(--background) !important;
+    background-color: var(--white) !important;
   }
 
   body.footer-visible::before {
     display: none;
+  }
+
+  /* Neutralize decorative accent colors for legibility */
+  .heading strong,
+  .heading :global(strong),
+  h1 strong, h2 strong, h3 strong, h4 strong, h5 strong, h6 strong {
+    color: var(--black) !important;
+  }
+
+  .paragraph.is-inverted,
+  p.is-inverted {
+    color: var(--black) !important;
+  }
+
+  /* Normalized typography scale for A4 */
+  .heading.size-lg  { font-size: 2.2rem !important; line-height: 1.3 !important; }
+  .heading.size-md  { font-size: 1.8rem !important; line-height: 1.3 !important; }
+  .heading.size-sm  { font-size: 1.4rem !important; line-height: 1.3 !important; }
+  .heading.size-xs  { font-size: 1.2rem !important; line-height: 1.3 !important; }
+  .heading.size-xxs { font-size: 1.1rem !important; line-height: 1.3 !important; }
+  .paragraph        { line-height: 1.45 !important; }
+
+  /* Page break rules - avoid cutting boxes and sections */
+  .job,
+  .card,
+  .item,
+  .knowledge-masonry,
+  .carousel-slide--flattened,
+  footer {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+
+  h1, h2, h3,
+  .heading {
+    break-after: avoid;
+    page-break-after: avoid;
   }
 
   /* Ensure images print correctly */
@@ -162,9 +214,10 @@
     text-align: left !important;
   }
 
-  /* Links - remove underlines */
+  /* Links - remove underlines and force black */
   a {
     text-decoration: none;
+    color: var(--black) !important;
   }
 
   /* Ensure proper contrast for print */


### PR DESCRIPTION
Force light theme and black text in @media print, normalize heading
scale for A4, add page-break rules, collapse Job/Skills/Knowledge/
Footer/Profile to single column, flatten Card decorative backgrounds,
skip MUI Masonry in Knowledge when flattened, and drop Hero from the
/print page entirely.

https://claude.ai/code/session_014h7TTMMGnrWUcYvcWVjsgf